### PR TITLE
Fix Join Requests feature for strict rooms

### DIFF
--- a/src/components/Room/JoinRequests/JoinRequests.js
+++ b/src/components/Room/JoinRequests/JoinRequests.js
@@ -1,18 +1,19 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import thumbsUp from '../../../assets/thumbs_up.png';
 import thumbsDown from '../../../assets/thumbs_down.png';
 import './JoinRequests.css';
 
 import { handleJoinRequest } from '../../../api/RoomzApiServiceClient.js';
 
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { setErrorMessage } from '../../../reducers/NotificationSlice';
+import { updateJoinRequests } from '../../../reducers/JoinRequestsSlice';
 import store from '../../../store';
 
 function JoinRequests() {
   const dispatch = useDispatch();
+  const pendingJoinRequests = useSelector(state => state.joinRequests.pending);
 
-  const [joinRequests, setJoinRequests] = useState([]);  // list of names of users requesting to join room
 
   /**
    * @function respondToJoinRequest - handler for host accepting/rejecting join request as host
@@ -32,7 +33,7 @@ function JoinRequests() {
         throw response['error'];
       }
 
-      // updateJoinRequests(); // TODO refresh join requests from the JoinRequests component
+      dispatch(updateJoinRequests(data));
 
     } catch (err) {
       console.log(':respondToJoinRequest: err=%o', err);
@@ -50,7 +51,7 @@ function JoinRequests() {
       <div className="room-requests-view">
         <p className="requests-title">Join Room Requests:</p>
 
-        {joinRequests.map((joinEntry, index) => (
+        {pendingJoinRequests.map((joinEntry, index) => (
           <div key={("request-%s", index)} className="pending-request-object">
             <div className="pending-select-options-container">
               <img id={("press-yes-%s", joinEntry.userId)} className="pending-img" src={thumbsUp} onClick={() => respondToJoinRequest(joinEntry, true)} alt="yes"/>

--- a/src/components/Room/Room.js
+++ b/src/components/Room/Room.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import './Room.css';
 

--- a/src/reducers/JoinRequestsSlice.js
+++ b/src/reducers/JoinRequestsSlice.js
@@ -1,0 +1,57 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
+import * as apiClient from '../api/RoomzApiServiceClient.js';
+
+
+/**
+ * @function updateJoinRequests - thunk to call api for chatMessage
+ * 
+ */
+const updateJoinRequests = createAsyncThunk(
+  'joinRequests/updateJoinRequests',
+  async(data) => {
+    await apiClient.getJoinRequests(data);
+    return {};
+  }
+);
+
+
+/**
+ * Slice for actions related to the JoinRequests component
+ * @see https://redux-toolkit.js.org/api/createSlice
+ */
+const joinRequestsSlice = createSlice({
+  name: 'joinRequests',
+  initialState: {
+    pending: [],
+  },
+  reducers: {
+
+    /**
+     * @reduxAction 'joinRequests/pending' - Set current join requests that are pending
+     * @param {Object} state - Initial state
+     * @param {Object} action.payload
+     */
+    setJoinRequests: (state, action) => {
+      state.pending = action.payload;
+    },
+
+
+    /**
+     * @reduxAction 'joinRequests/clearJoinRequests' - Clear join requests
+     * @param {Object} state - Initial state
+     */
+    clearJoinRequests: (state) => {
+      state.pending = [];
+    },
+  },
+  extraReducers: {}
+});
+
+/**
+ * Actions
+ */
+export const { setJoinRequests, clearJoinRequests } = joinRequestsSlice.actions;
+export { updateJoinRequests }
+
+export default joinRequestsSlice;

--- a/src/reducers/JoinRequestsSlice.js
+++ b/src/reducers/JoinRequestsSlice.js
@@ -4,7 +4,7 @@ import * as apiClient from '../api/RoomzApiServiceClient.js';
 
 
 /**
- * @function updateJoinRequests - thunk to call api for chatMessage
+ * @function updateJoinRequests - thunk to call api for getJoinRequests
  * 
  */
 const updateJoinRequests = createAsyncThunk(
@@ -15,7 +15,7 @@ const updateJoinRequests = createAsyncThunk(
     let joinRequests = [];
     let incomingJoinRequests = response.getJoinRequestsList();
 
-    for (var i = 0; i < incomingJoinRequests.length; i++) {
+    for (let i = 0; i < incomingJoinRequests.length; i++) {
       joinRequests.push({
         userId: incomingJoinRequests[i].getUserId(),
         name: incomingJoinRequests[i].getUserName(),

--- a/src/reducers/JoinRequestsSlice.js
+++ b/src/reducers/JoinRequestsSlice.js
@@ -10,8 +10,22 @@ import * as apiClient from '../api/RoomzApiServiceClient.js';
 const updateJoinRequests = createAsyncThunk(
   'joinRequests/updateJoinRequests',
   async(data) => {
-    await apiClient.getJoinRequests(data);
-    return {};
+    const response = await apiClient.getJoinRequests(data);
+
+    let joinRequests = [];
+    let incomingJoinRequests = response.getJoinRequestsList();
+
+    for (var i = 0; i < incomingJoinRequests.length; i++) {
+      joinRequests.push({
+        userId: incomingJoinRequests[i].getUserId(),
+        name: incomingJoinRequests[i].getUserName(),
+      });
+    }
+
+    const payload = {
+      pending: joinRequests,
+    };
+    return payload;
   }
 );
 
@@ -45,7 +59,17 @@ const joinRequestsSlice = createSlice({
       state.pending = [];
     },
   },
-  extraReducers: {}
+  extraReducers: {
+    /**
+     * @reduxAction 'joinRequests/updateJoinRequests/fulfilled' - update `pending` to retrieved join requests
+     * @param {Object} state - Initial state
+     * @param {Object} action.payload
+     * @param {Array} action.payload.pending
+     */
+    [updateJoinRequests.fulfilled]: (state, action) => {
+      state.pending = action.payload.pending;
+    },
+  }
 });
 
 /**

--- a/src/reducers/RootReducer.js
+++ b/src/reducers/RootReducer.js
@@ -4,6 +4,7 @@ import roomSlice from './RoomSlice';
 import chatroomSlice from './ChatroomSlice';
 import vestibuleSlice from './VestibuleSlice';
 import notificationSlice from './NotificationSlice';
+import joinRequestsSlice from './JoinRequestsSlice';
 
 
 /**
@@ -17,4 +18,5 @@ export const rootReducer = combineReducers({
   chatroom: chatroomSlice.reducer,
   vestibule: vestibuleSlice.reducer,
   notification: notificationSlice.reducer,
+  joinRequests: joinRequestsSlice.reducer,
 });


### PR DESCRIPTION
Previous PR had some regression where the join requests feature was broken. It is now working properly.
- added new `JoinRequestSlice`, which means array of join requests are now globally stored in the `store`
- styling is still not ideal, but this PR is mainly for functionality

![image](https://user-images.githubusercontent.com/16727403/118762216-b208f200-b82a-11eb-8384-36120753f436.png)
