### PR TITLE
Media Icons toggle on/off

### DIFF
--- a/src/components/Room/RoomBottomPanel/RoomBottomPanel.js
+++ b/src/components/Room/RoomBottomPanel/RoomBottomPanel.js
@@ -188,11 +188,11 @@ function RoomBottomPanel(props) {
       return (
         <div className="room-bottom-panel-actions">
           <IconButton aria-label="toggle mic" onClick={toggleAudio}>
-              <MicIcon />
-            </IconButton>
-            <IconButton aria-label="toggle video" onClick={toggleVideo}>
-              <VideocamIcon />
-            </IconButton>
+            <MicIcon />
+          </IconButton>
+          <IconButton aria-label="toggle video" onClick={toggleVideo}>
+            <VideocamIcon />
+          </IconButton>
           <IconButton aria-label="leave room" onClick={roomLeaveAsNonHost}>
             <CallEndIcon />
           </IconButton>

--- a/src/components/Room/RoomBottomPanel/RoomBottomPanel.js
+++ b/src/components/Room/RoomBottomPanel/RoomBottomPanel.js
@@ -174,10 +174,10 @@ function RoomBottomPanel(props) {
       return (
         <div className="room-bottom-panel-actions">
           <IconButton aria-label="toggle mic" onClick={toggleAudio}>
-            <MicIcon />
+            {store.getState().media.audioOn ? <MicIcon /> : <MicOffIcon />}
           </IconButton>
           <IconButton aria-label="toggle video" onClick={toggleVideo}>
-            <VideocamIcon />
+            {store.getState().media.videoOn ? <VideocamIcon /> : <VideocamOffIcon />}
           </IconButton>
           <IconButton aria-label="close room" onClick={roomDeleteAsHost}>
             <CallEndIcon />
@@ -188,10 +188,10 @@ function RoomBottomPanel(props) {
       return (
         <div className="room-bottom-panel-actions">
           <IconButton aria-label="toggle mic" onClick={toggleAudio}>
-            <MicIcon />
+            {store.getState().media.audioOn ? <MicIcon /> : <MicOffIcon />}
           </IconButton>
           <IconButton aria-label="toggle video" onClick={toggleVideo}>
-            <VideocamIcon />
+            {store.getState().media.videoOn ? <VideocamIcon /> : <VideocamOffIcon />}
           </IconButton>
           <IconButton aria-label="leave room" onClick={roomLeaveAsNonHost}>
             <CallEndIcon />

--- a/src/components/Room/RoomBottomPanel/RoomBottomPanel.js
+++ b/src/components/Room/RoomBottomPanel/RoomBottomPanel.js
@@ -19,6 +19,7 @@ import { clearChatHistory, toggleChatroom } from '../../../reducers/ChatroomSlic
 import { setErrorMessage } from '../../../reducers/NotificationSlice';
 import { roomDelete, roomLeave } from '../../../reducers/RoomSlice';
 import { setVisible, updateJoinRequests, clearJoinRequests } from '../../../reducers/JoinRequestsSlice';
+import { setAudioOn, setVideoOn } from '../../../reducers/MediaSlice';
 
 import store from '../../../store';
 
@@ -138,6 +139,7 @@ function RoomBottomPanel(props) {
       'action': 'ToggleAudioStream',
     }
     props.dispatchMediaStreams(toggleAudioData);
+    dispatch(setAudioOn(!store.getState().media.audioOn));
   }
 
   /**
@@ -149,6 +151,7 @@ function RoomBottomPanel(props) {
       'action': 'ToggleVideoStream',
     }
     props.dispatchMediaStreams(toggleVideoData);
+    dispatch(setVideoOn(!store.getState().media.videoOn));
   }
 
 

--- a/src/components/Vestibule/MediaPreview/MediaPreview.css
+++ b/src/components/Vestibule/MediaPreview/MediaPreview.css
@@ -13,4 +13,10 @@
 
 .media-btns {
   display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
+.media-btns button {
+  margin: 12px 20px;
 }

--- a/src/components/Vestibule/MediaPreview/MediaPreview.js
+++ b/src/components/Vestibule/MediaPreview/MediaPreview.js
@@ -87,6 +87,7 @@ function MediaPreview(props) {
       setStream(null);
     }
   }
+
   
   return (
     <div className="media-preview">
@@ -99,10 +100,10 @@ function MediaPreview(props) {
     : <div className="media-preview-placeholder"/>}
     <div className="media-btns">
       <IconButton aria-label="toggle mic" onClick={toggleAudio}>
-        <MicIcon />
+        {store.getState().media.audioOn ? <MicIcon /> : <MicOffIcon />}
       </IconButton>
       <IconButton aria-label="toggle video" onClick={toggleVideo}>
-        <VideocamIcon />
+        {store.getState().media.videoOn ? <VideocamIcon /> : <VideocamOffIcon />}
       </IconButton>
     </div>
     </div>

--- a/src/components/Vestibule/MediaPreview/MediaPreview.js
+++ b/src/components/Vestibule/MediaPreview/MediaPreview.js
@@ -9,9 +9,13 @@ import MicOffIcon from '@material-ui/icons/MicOff';
 import VideocamIcon from '@material-ui/icons/Videocam';
 import VideocamOffIcon from '@material-ui/icons/VideocamOff';
 
+import { useDispatch } from 'react-redux';
+import { setAudioOn, setVideoOn } from '../../../reducers/MediaSlice';
 import store from '../../../store';
 
 function MediaPreview(props) {
+  const dispatch = useDispatch();
+
   const [stream, setStream] = useState(null);
   const [peerId, setPeerId] = useState("");
 
@@ -37,6 +41,8 @@ function MediaPreview(props) {
     navigator.getUserMedia({'audio': true, 'video': true},
       function(localMediaStream) {
         console.log('Granted access to audio/video, setting stream.');
+        dispatch(setAudioOn(true));
+        dispatch(setVideoOn(true));
         setStream(localMediaStream);
 
         if (addStreamToRoom) {
@@ -54,6 +60,8 @@ function MediaPreview(props) {
       },
       function() {
         console.log('Access denied for audio/video');
+        dispatch(setAudioOn(false));
+        dispatch(setVideoOn(false));
         alert('Have fun being lame on zoom');
       });
   }
@@ -67,6 +75,7 @@ function MediaPreview(props) {
       'action': 'ToggleAudioStream',
     }
     props.dispatchMediaStreams(toggleAudioData);
+    dispatch(setAudioOn(!store.getState().media.audioOn));
   }
   
   /**
@@ -78,6 +87,7 @@ function MediaPreview(props) {
       'action': 'ToggleVideoStream',
     }
     props.dispatchMediaStreams(toggleVideoData);
+    dispatch(setVideoOn(!store.getState().media.videoOn));
 
     // toggle local stream view
     if (stream === null) {

--- a/src/components/Vestibule/MediaPreview/MediaPreview.js
+++ b/src/components/Vestibule/MediaPreview/MediaPreview.js
@@ -3,6 +3,11 @@ import Video from '../../Video';
 import Avatar from '@material-ui/core/Avatar';
 
 import './MediaPreview.css';
+import IconButton from '@material-ui/core/IconButton';
+import MicIcon from '@material-ui/icons/Mic';
+import MicOffIcon from '@material-ui/icons/MicOff';
+import VideocamIcon from '@material-ui/icons/Videocam';
+import VideocamOffIcon from '@material-ui/icons/VideocamOff';
 
 import store from '../../../store';
 
@@ -93,8 +98,12 @@ function MediaPreview(props) {
         />
     : <div className="media-preview-placeholder"/>}
     <div className="media-btns">
-      <Avatar className="avatar-placeholder" onClick={toggleAudio}>A</Avatar>
-      <Avatar className="avatar-placeholder" onClick={toggleVideo}>V</Avatar>
+      <IconButton aria-label="toggle mic" onClick={toggleAudio}>
+        <MicIcon />
+      </IconButton>
+      <IconButton aria-label="toggle video" onClick={toggleVideo}>
+        <VideocamIcon />
+      </IconButton>
     </div>
     </div>
   );

--- a/src/reducers/MediaSlice.js
+++ b/src/reducers/MediaSlice.js
@@ -1,0 +1,42 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+/**
+ * Slice for actions related to Media
+ * @see https://redux-toolkit.js.org/api/createSlice
+ */
+ const mediaSlice = createSlice({
+  name: 'media',
+  initialState: {
+    audioOn: false,
+    videoOn: false,
+  },
+  reducers: {
+
+    /**
+     * @reduxAction 'media/setAudioOn' - Set audioOn boolean
+     * @param {Object} state - Initial state
+     * @param {boolean} action.payload
+     */
+     setAudioOn: (state, action) => {
+      state.audioOn = action.payload;
+    },
+
+    /**
+     * @reduxAction 'media/setVideoOn' - Set videoOn boolean
+     * @param {Object} state - Initial state
+     * @param {boolean} action.payload
+     */
+     setVideoOn: (state, action) => {
+      state.videoOn = action.payload;
+    },
+
+  },
+  extraReducers: {}
+});
+
+/**
+ * Actions
+ */
+export const { setAudioOn, setVideoOn } = mediaSlice.actions;
+
+export default mediaSlice;

--- a/src/reducers/RootReducer.js
+++ b/src/reducers/RootReducer.js
@@ -4,6 +4,7 @@ import roomSlice from './RoomSlice';
 import chatroomSlice from './ChatroomSlice';
 import notificationSlice from './NotificationSlice';
 import joinRequestsSlice from './JoinRequestsSlice';
+import mediaSlice from './MediaSlice';
 
 
 /**
@@ -17,4 +18,5 @@ export const rootReducer = combineReducers({
   chatroom: chatroomSlice.reducer,
   notification: notificationSlice.reducer,
   joinRequests: joinRequestsSlice.reducer,
+  media: mediaSlice.reducer,
 });


### PR DESCRIPTION
5 min change became a change that took at least an hour 🙃

Added MediaSlice to keep track of state for `audio` and `video` being on/off. This is due to the user being able to enter the room and audio/video needs to stay on or off. Hopefully it isn't too much of an issue that I added another slice. Also slightly confusing that now there is `MediaSlice` and `MediaReducers` oh well.
- `MediaPreview` (in Vestibule) button icons now match `RoomBottomPanel`
- new `MediaSlice` file with `audioOn` and `videoOn` state. Naming is hard so I'm open to changing the names
- `MediaPreview` updates its media button icons based on state
- `RoomBottomPanel` updates its media button icons based on state
- I determine the initial state of `audioOn` and `videoOn` based on the function `MediaPreview.setupLocalMedia`

Example with entering room with video off:
![enter_video_off](https://user-images.githubusercontent.com/16727403/122168926-b298a680-ce31-11eb-8f6c-74676d12072d.gif)


Example with entering room with video on:
![enter_video_on](https://user-images.githubusercontent.com/16727403/122169317-2044d280-ce32-11eb-98fb-dc9f4d6cd9ae.gif)
